### PR TITLE
Fix to typos in data structure's test description

### DIFF
--- a/test-description/data-structure.md
+++ b/test-description/data-structure.md
@@ -255,7 +255,7 @@ _SessionSeries example_
     *   seller
     *   broker
     *   brokerRole
-    *   ustomer
+    *   customer
     *   taxCalculationExcluded
     *   bookingService
     *   totalPaymentDue
@@ -272,11 +272,11 @@ _Slots example_
     *     provider
     *     location
     *     offers
-    *     Event
+    *     event
 
 _Event example_
 
-*   Event.attendeeinstructions exists
+*   Event.attendeeInstructions exists
 *   Event has no properties beyond
     *   type
     *   url


### PR DESCRIPTION
@nickevansuk this is mainly to avoid confusion around casing