### PR TITLE
Fix name attribute for broker organization in Order example

### DIFF
--- a/test-description/data-structure.md
+++ b/test-description/data-structure.md
@@ -86,7 +86,7 @@
 	},
 	"broker": {
 		"type": "Organization",
-		"schema": "Fencing Booking Partners"
+		"name": "Fencing Booking Partners"
 	},
 	"brokerRole": "https://openactive/AgentBroker",
 	"customer": {


### PR DESCRIPTION
@nickevansuk Couldn't quite find a "schema" attribute across the Organization model, could this be the "name"?