### PR TITLE
Specified activity id to be URL

### DIFF
--- a/test-description/formatting.md
+++ b/test-description/formatting.md
@@ -126,4 +126,4 @@
 
 **URLs**
 
-*   SessionSeries.id, SessionSeries.activity, and SessionSeries.subEvent.url are both correctly-formatted URLs
+*   SessionSeries.id, SessionSeries.activity.id, and SessionSeries.subEvent.url are both correctly-formatted URLs


### PR DESCRIPTION
Activity is technically an object of type `Concept`. `id` and/or `url` should be the one to check the format against.