### PR TITLE
Add beta notice to class's docblock if not a schema.org model.

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -654,6 +654,7 @@ class Generator {
 
     let docLines = [
       this.getPropNameFromFQP(model.type) !== model.type &&
+        model.type.indexOf("schema:") !== 0 &&
         `[NOTICE: This is a beta class, and is highly likely to change in future versions of this library.].`,
       this.createCommentFromDescription(model.description)
     ];

--- a/src/generator.js
+++ b/src/generator.js
@@ -654,7 +654,7 @@ class Generator {
 
     let docLines = [
       this.getPropNameFromFQP(model.type) !== model.type &&
-        model.type.indexOf("schema:") !== 0 &&
+        !model.type.startsWith("schema:") &&
         `[NOTICE: This is a beta class, and is highly likely to change in future versions of this library.].`,
       this.createCommentFromDescription(model.description)
     ];


### PR DESCRIPTION
Previously all models not in the current OA spec (schema.org and beta's) contained a class docblock noting the class was beta. This prevent schema.org models to have this notice.