### PR TITLE
Throw better exception if type not valid in PHP model

### DIFF
--- a/src/generators/php/model.php.mustache
+++ b/src/generators/php/model.php.mustache
@@ -37,7 +37,7 @@ class {{{className}}} extends {{{ inherits }}}
     /**
      * @param {{{propertyType}}} ${{{propName}}}
      * @return void
-     * @throws \InvalidArgumentException If the provided argument is not of a supported type.
+     * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function set{{{pascalCasePropName}}}(${{{propName}}})
     {

--- a/src/generators/php/model.php.mustache
+++ b/src/generators/php/model.php.mustache
@@ -37,7 +37,7 @@ class {{{className}}} extends {{{ inherits }}}
     /**
      * @param {{{propertyType}}} ${{{propName}}}
      * @return void
-     * @throws \Exception If the provided argument is not of a supported type.
+     * @throws \InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function set{{{pascalCasePropName}}}(${{{propName}}})
     {


### PR DESCRIPTION
Quick PR - this exception is semantically more correct than a generic Exception, see: https://www.php.net/manual/en/class.invalidargumentexception.php