### PR TITLE
Added obsolete fields support for PHP generator

### DIFF
--- a/src/generators/php/index.js
+++ b/src/generators/php/index.js
@@ -251,10 +251,7 @@ class PHP extends Generator {
     if (field.obsolete) {
       return {
         ...obj,
-        decorators: [
-          `[Obsolete("This property is disinherited in this type, and must not be used.", true)]`
-        ],
-        property: `public override ${propertyType} ${propertyName} { get; set; }`
+        isObsolete: true,
       };
     } else {
       let methodType = "";

--- a/src/generators/php/model.php.mustache
+++ b/src/generators/php/model.php.mustache
@@ -21,6 +21,9 @@ class {{{className}}} extends {{{ inherits }}}
 {{/codeExample }}
      *
      * @var {{{propertyType}}}
+{{#if isObsolete}}
+     * @deprecated This property is disinherited in this type, and must not be used.
+{{/if}}
      */
     protected ${{{propName}}};
 
@@ -28,6 +31,9 @@ class {{{className}}} extends {{{ inherits }}}
 {{#fieldList}}
     /**
      * @return {{{propertyType}}}
+{{#if isObsolete}}
+     * @deprecated This property is disinherited in this type, and must not be used.
+{{/if}}
      */
     public function get{{{pascalCasePropName}}}()
     {
@@ -38,6 +44,9 @@ class {{{className}}} extends {{{ inherits }}}
      * @param {{{propertyType}}} ${{{propName}}}
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
+{{#if isObsolete}}
+     * @deprecated This property is disinherited in this type, and must not be used.
+{{/if}}
      */
     public function set{{{pascalCasePropName}}}(${{{propName}}})
     {


### PR DESCRIPTION
This PR adds support for marking obsolete fields as `@depreacted` in the PHP generator.

The variable, getter, and setter, will all be marked as `@deprecated` for an obsolete attribute.