### PR TITLE
Add an internal Time type to PHP

### DIFF
--- a/src/generators/php/index.js
+++ b/src/generators/php/index.js
@@ -88,8 +88,18 @@ class PHP extends Generator {
     return value;
   }
 
-  getLangType(fullyQualifiedType, enumMap, modelsMap, isExtension) {
-    let baseType = this.getLangBaseType(
+  internalTypeToLangType(internalType) {
+    if(internalType === "Time") {
+      return "string";
+    }
+    if(internalType === "Time[]") {
+      return "string[]";
+    }
+    return internalType;
+  }
+
+  getInternalType(fullyQualifiedType, enumMap, modelsMap, isExtension) {
+    let baseType = this.getInternalBaseType(
       fullyQualifiedType,
       enumMap,
       modelsMap,
@@ -107,7 +117,7 @@ class PHP extends Generator {
     }
   }
 
-  getLangBaseType(prefixedTypeName, enumMap, modelsMap, isExtension) {
+  getInternalBaseType(prefixedTypeName, enumMap, modelsMap, isExtension) {
     let typeName = this.getPropNameFromFQP(prefixedTypeName);
     switch (typeName) {
       case "Boolean":
@@ -277,7 +287,9 @@ class PHP extends Generator {
   }
 
   createTypeString(field, models, enumMap, isExtension) {
-    const types = this.createTypesArray(field, models, enumMap, isExtension);
+    const internalTypes = this.createTypesArray(field, models, enumMap, isExtension);
+
+    const types = internalTypes.map(type => this.internalTypeToLangType(type));
 
     // OpenActive SingleValues not allow many of the same type, only allows one
     return types.length > 1 ? `${types.join("|")}` : types[0];
@@ -304,7 +316,7 @@ class PHP extends Generator {
     // and filter out duplicated types
     types = types
       .map(fullyQualifiedType =>
-        this.getLangType(fullyQualifiedType, enumMap, models, isExtension)
+        this.getInternalType(fullyQualifiedType, enumMap, models, isExtension)
       )
       .filter((val, idx, self) => self.indexOf(val) === idx);
 

--- a/src/generators/php/index.js
+++ b/src/generators/php/index.js
@@ -114,8 +114,9 @@ class PHP extends Generator {
         return "bool";
       case "Date": // TODO: Find better way of representing Date
       case "DateTime":
-      case "Time":
         return "DateTime";
+      case "Time":
+        return "Time";
       case "Integer":
         return "int";
       case "Float":

--- a/src/generators/php/index.js
+++ b/src/generators/php/index.js
@@ -88,18 +88,18 @@ class PHP extends Generator {
     return value;
   }
 
-  internalTypeToLangType(internalType) {
-    if(internalType === "Time") {
+  validationTypeToLangType(validationType) {
+    if(validationType === "Time") {
       return "string";
     }
-    if(internalType === "Time[]") {
+    if(validationType === "Time[]") {
       return "string[]";
     }
-    return internalType;
+    return validationType;
   }
 
-  getInternalType(fullyQualifiedType, enumMap, modelsMap, isExtension) {
-    let baseType = this.getInternalBaseType(
+  getValidationType(fullyQualifiedType, enumMap, modelsMap, isExtension) {
+    let baseType = this.getValidationBaseType(
       fullyQualifiedType,
       enumMap,
       modelsMap,
@@ -117,7 +117,7 @@ class PHP extends Generator {
     }
   }
 
-  getInternalBaseType(prefixedTypeName, enumMap, modelsMap, isExtension) {
+  getValidationBaseType(prefixedTypeName, enumMap, modelsMap, isExtension) {
     let typeName = this.getPropNameFromFQP(prefixedTypeName);
     switch (typeName) {
       case "Boolean":
@@ -237,13 +237,13 @@ class PHP extends Generator {
     let isExtension = !!field.extensionPrefix;
     let isNew = field.derivedFromSchema; // Only need new if sameAs specified as it will be replacing a schema.org type
     let propertyName = this.convertToCamelCase(field.fieldName);
-    let propertyType = this.createTypeString(
+    let propertyType = this.createLangTypeString(
       field,
       models,
       enumMap,
       isExtension
     );
-    let propertyTypes = this.createTypesArray(
+    let propertyTypes = this.createValidationTypesArray(
       field,
       models,
       enumMap,
@@ -286,16 +286,16 @@ class PHP extends Generator {
     }
   }
 
-  createTypeString(field, models, enumMap, isExtension) {
-    const internalTypes = this.createTypesArray(field, models, enumMap, isExtension);
+  createLangTypeString(field, models, enumMap, isExtension) {
+    const validationTypes = this.createValidationTypesArray(field, models, enumMap, isExtension);
 
-    const types = internalTypes.map(type => this.internalTypeToLangType(type));
+    const types = validationTypes.map(type => this.validationTypeToLangType(type));
 
     // OpenActive SingleValues not allow many of the same type, only allows one
     return types.length > 1 ? `${types.join("|")}` : types[0];
   }
 
-  createTypesArray(field, models, enumMap, isExtension) {
+  createValidationTypesArray(field, models, enumMap, isExtension) {
     let types = []
       .concat(field.alternativeTypes)
       .concat(field.requiredType)
@@ -316,7 +316,7 @@ class PHP extends Generator {
     // and filter out duplicated types
     types = types
       .map(fullyQualifiedType =>
-        this.getInternalType(fullyQualifiedType, enumMap, models, isExtension)
+        this.getValidationType(fullyQualifiedType, enumMap, models, isExtension)
       )
       .filter((val, idx, self) => self.indexOf(val) === idx);
 


### PR DESCRIPTION
Rather than assuming properties of type Time should be represented as DateTime objects in PHP, now list the types to check against as "Time" but keep the PHP representation as a string (because there is no neat Time object in PHP and adding one seemed overkill).

This allows Time-type properties to be checked against the Time validator but the doc string to say they are strings.

Output of these changes and the TimeValidator can be seen here: https://github.com/openactive/models-php/pull/27