### PR TITLE
[PHP generator] - Schema.org Number handling

### DIFF
--- a/src/generators/php/index.js
+++ b/src/generators/php/index.js
@@ -130,9 +130,8 @@ class PHP extends Generator {
       case "Integer":
         return "int";
       case "Float":
-        return "float";
       case "Number":
-        return "decimal";
+        return "float";
       case "Property":
       case "Text":
       case "URL":


### PR DESCRIPTION
Fixed PHP generation of `Number` schema.org type - now mapped to `float` as `decimal` is not a PHP type.