### PR TITLE
Remove .NET enum type for schema.org

### DIFF
--- a/src/generators/php/index.js
+++ b/src/generators/php/index.js
@@ -143,12 +143,9 @@ class PHP extends Generator {
       default:
         if (enumMap[typeName]) {
           if (this.includedInSchema(enumMap[typeName].namespace)) {
-            return "Schema.NET." + this.convertToCamelCase(typeName);
+            return "\\OpenActive\\Enums\\" + this.convertToCamelCase(typeName);
           } else {
-            return (
-              "\\OpenActive\\Enums\\" +
-              this.convertToCamelCase(typeName)
-            );
+            return "\\OpenActive\\Enums\\" + this.convertToCamelCase(typeName);
           }
         } else if (modelsMap[typeName]) {
           return this.convertToCamelCase(typeName);

--- a/src/generators/php/index.js
+++ b/src/generators/php/index.js
@@ -142,11 +142,7 @@ class PHP extends Generator {
         return "null";
       default:
         if (enumMap[typeName]) {
-          if (this.includedInSchema(enumMap[typeName].namespace)) {
-            return "\\OpenActive\\Enums\\" + this.convertToCamelCase(typeName);
-          } else {
-            return "\\OpenActive\\Enums\\" + this.convertToCamelCase(typeName);
-          }
+          return "\\OpenActive\\Enums\\" + this.convertToCamelCase(typeName);
         } else if (modelsMap[typeName]) {
           return this.convertToCamelCase(typeName);
         } else if (isExtension) {

--- a/src/generators/php/index.js
+++ b/src/generators/php/index.js
@@ -142,6 +142,7 @@ class PHP extends Generator {
         return "null";
       default:
         if (enumMap[typeName]) {
+          // TODO: OA and SchemaOrg use same namespace: do we need to differentiate?
           return "\\OpenActive\\Enums\\" + this.convertToCamelCase(typeName);
         } else if (modelsMap[typeName]) {
           return this.convertToCamelCase(typeName);


### PR DESCRIPTION
This PR exclusively fixes the namespace, and doesn't deliberately fix the empty `SchemaOrg\Enums` classes. That will land in a different PR.