### PR TITLE
Convert to classname PHP port

### DIFF
--- a/src/generators/php/index.js
+++ b/src/generators/php/index.js
@@ -95,6 +95,9 @@ class PHP extends Generator {
   }
 
   convertToClassName(value) {
+    // 3DModel is an invalid class name..
+    value = value.replace(/^3/, "Three");
+    
     return this.convertToCamelCase(value);
   }
 


### PR DESCRIPTION
Replaces leading `3` in class names with `Three` as PHP (like Ruby) doesn't support class names starting with a number.