### PR TITLE
fix: Numeric type and shorter array syntax

### DIFF
--- a/src/generators/php/index.js
+++ b/src/generators/php/index.js
@@ -152,8 +152,9 @@ class PHP extends Generator {
       case "Integer":
         return "int";
       case "Float":
-      case "Number":
         return "float";
+      case "Number":
+        return "Number";
       case "Property":
       case "Text":
       case "URL":

--- a/src/generators/php/model.php.mustache
+++ b/src/generators/php/model.php.mustache
@@ -68,11 +68,11 @@ class {{{className}}} extends {{{ inherits }}}
      */
     public function set{{{pascalCasePropName}}}(${{{propName}}})
     {
-        $types = array(
+        $types = [
 {{# propertyTypes }}
             "{{{ . }}}",
 {{/propertyTypes }}
-        );
+        ];
 
         ${{{propName}}} = self::checkTypes(${{{propName}}}, $types);
 


### PR DESCRIPTION
Updates to use a new Numeric type to handle explicit number types without floating-point issues. Switches PHP to use the short-array syntax (added in PHP 5.4).

(migrated from #37)