### PR TITLE
Fix OA model namespaces

### DIFF
--- a/src/generators/php/index.js
+++ b/src/generators/php/index.js
@@ -171,7 +171,7 @@ class PHP extends Generator {
           }
           return "\\OpenActive\\Enums\\" + camelName;
         } else if (this.models[typeName] && extension && extension.preferOA) {
-          return "\\OpenActive\\Models\\" + camelName;
+          return "\\OpenActive\\Models\\OA\\" + camelName;
         } else if (this.models[compactedTypeName]) {
           if (this.includedInSchema(compactedTypeName)) {
             return "\\OpenActive\\Models\\SchemaOrg\\" + camelName;


### PR DESCRIPTION
Solves https://github.com/openactive/models-lib/issues/49 whereby some model namespaces are referenced without including `\OA\`